### PR TITLE
feat: preserve HTML tags when updating Anki sentence field

### DIFF
--- a/page/src/App.vue
+++ b/page/src/App.vue
@@ -4,6 +4,7 @@
   import { useWebSocket } from './composables/useWebSocket'
   import * as anki from './services/ankiConnect'
   import { isJsonObject, type JsonObject, type JsonValue } from './types/json'
+  import { preserveHtmlTags } from './utils/htmlUtils'
 
   const DEFAULT_PORTS = [61777, 61778, 61779, 61780, 61781]
 
@@ -561,7 +562,8 @@
 
       if (sentenceField) {
         const text = selectedMsgs.map((m) => m.subtitle).join(' ')
-        fieldUpdates[sentenceField] = text
+        const existingSentence = targetNote.fields[sentenceField]?.value ?? ''
+        fieldUpdates[sentenceField] = preserveHtmlTags(existingSentence, text)
       }
 
       if (audioField) {

--- a/page/src/utils/htmlUtils.ts
+++ b/page/src/utils/htmlUtils.ts
@@ -1,0 +1,66 @@
+/**
+ * @param original - The existing sentence
+ * @param updated - The new sentence text without tags
+ * @returns The updated sentence with HTML tags
+ */
+export function preserveHtmlTags(original: string, updated: string): string {
+  if (!original || !updated) {
+    return updated
+  }
+
+  // Extract all tagged segments from the original
+  const taggedSegments = extractTaggedSegments(original)
+
+  if (taggedSegments.length === 0) {
+    return updated.trim()
+  }
+
+  let result = updated.trim()
+
+  // For each tagged segment, find and re-wrap in the new text
+  for (const segment of taggedSegments) {
+    const searchText = segment.innerText.trim()
+    if (!searchText) continue
+
+    // Try to find the exact text in the result
+    const position = result.indexOf(searchText)
+    if (position !== -1) {
+      // Reconstruct with the original tag
+      const before = result.substring(0, position)
+      const after = result.substring(position + searchText.length)
+      result = `${before}${segment.openTag}${searchText}${segment.closeTag}${after}`
+    }
+  }
+
+  return result
+}
+
+interface TaggedSegment {
+  openTag: string
+  closeTag: string
+  innerText: string
+}
+
+/**
+ * Finds all HTML tag pairs and their contents in a string.
+ * Handles tags like <b>, <strong>, <span class="...">, etc.
+ */
+function extractTaggedSegments(text: string): TaggedSegment[] {
+  const segments: TaggedSegment[] = []
+
+  // Match opening tag, content, closing tag
+  // Group 1: full opening tag, Group 2: tag name, Group 3: inner content
+  const pattern = /<([a-zA-Z][a-zA-Z0-9]*)(?:\s[^>]*)?>([^<]*)<\/\1>/g
+
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(text)) !== null) {
+    const tagName = match[1]
+    const openTag = match[0].substring(0, match[0].indexOf('>') + 1)
+    const innerText = match[2] ?? ''
+    const closeTag = `</${tagName}>`
+
+    segments.push({ openTag, closeTag, innerText })
+  }
+
+  return segments
+}


### PR DESCRIPTION
This PR implements logic to preserve HTML tags (like <b>...</b>) from the original Anki card when updating the sentence field.

- Adds a new preserveHtmlTags utility function (page/src/utils/htmlUtils.ts).
-  Updates App.vue (page/src/App.vue) to use this utility when updating the sentence.

I did some testing with this change, and it seems to work. I also tried selecting multiple sentences at once and running “AJT Japanese: Bulk-generate,” and the tags were preserved.

Before:
<img width="864" height="386" alt="screenshot-20260122-141702" src="https://github.com/user-attachments/assets/961d5764-f90a-422f-a80f-2596c84291a1" />

After:
<img width="867" height="395" alt="screenshot-20260122-141647" src="https://github.com/user-attachments/assets/002fe0f0-94db-42e0-a986-564107bf45cc" />
