### PR TITLE
Update settings override identifier

### DIFF
--- a/mpv/mpv-subtitleminer.lua
+++ b/mpv/mpv-subtitleminer.lua
@@ -2,7 +2,7 @@ local utils = require("mp.utils")
 local options = require("mp.options")
 
 local opts = {
-  -- Either adjust settings here OR in script-opts/run_server.conf
+  -- Either adjust settings here OR in script-opts/mpv-subtitleminer.conf
   -- ========== SETTINGS ==========
   -- List of ports to try starting the server on.
   ports = { 61777, 61778, 61779, 61780, 61781 },
@@ -11,7 +11,7 @@ local opts = {
   -- ==============================
 }
 
-options.read_options(opts, "run_server")
+options.read_options(opts, "mpv-subtitleminer")
 
 -- Convert ports from string to table if needed
 if type(opts.ports) == "string" then


### PR DESCRIPTION
The script was renamed from `run_server.lua` to `mpv-subtitleminer.lua`, but the identifier for overriding the settings wasn't updated. This updates it to match the new name.

In theory, the identifier parameter can be left off per [the documentation](https://mpv.io/manual/stable/#mp-options-functions):

>The identifier is used to identify the config-file and the command-line options. These needs to unique to avoid collisions with other scripts. Defaults to mp.get_script_name() if the parameter is nil or missing.

However, mpv's output of `get_script_name` is described [here](https://mpv.io/manual/stable/#lua-scripting-mp-get-script-name()) as:

> Return the name of the current script. The name is usually made of the filename of the script, with directory and file extension removed. If there are several scripts which would have the same name, it's made unique by appending a number. Any nonalphanumeric characters are replaced with _.
> 
> **Example**
> The script /path/to/foo-script.lua becomes foo_script.


So the script (and then the conf file) would have to be named `mpv_subtitleminer.lua` for that to work, since it converts the `-` into an `_`.

Instead of doing that, this just keeps the identifier parameter to at least have the conf file's name in line with the current Lua file's actual name.